### PR TITLE
fix: use correct branch name in workflow

### DIFF
--- a/.github/workflows/copydocs.yml
+++ b/.github/workflows/copydocs.yml
@@ -2,7 +2,7 @@ name: Copy docs to branch
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Richard Case <richard.case@outlook.com>